### PR TITLE
Fix fill triangle bug (issue #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ The module has been tested on a Raspberry Pi Pico with a 128x128 pixel SH1107 di
 
 ## Methods
 
-`large_text(s, x, y, m [, c=1] [, r=0 [, t=None]])` 
+**`large_text(s, x, y, m [, c=1] [, r=0 [, t=None]])`**
 
 Write text, `s`, to a FrameBuffer using the the `x` and `y` coordinates as the upper-left corner of the text. The colour of the text can be defined by the optional argument, `c`, but is otherwise a default value of 1. The parameter `m` sets the size multiple for the text. The normal size for text with the 'FrameBuffer.text()' method is 8x8 pixels. This would be a multiple of 1. To obtain larger text output, with 16x16 pixel characters, for example, use 2 for the m parameter. The optional parameter r controls the rotation of the text, 0 degrees is the default, 90, 180 and 270 degrees are possible. In addition the t parameter enables individual characters within a string to be independently rotated to 0, 90, 180 or 270 degrees. 
 
-`circle(x0, y0, radius, c [, f:bool] )` 
+**`circle(x0, y0, radius, c [, f:bool] )`** 
 
 Draw a circle centred on `x0, y0` with the specified `radius` and border colour, `c` (integer). Optionally fill the circle by adding `f=True`.
 
-`triangle(x0, y0, x1, y1, x2, y2, c [, f:bool] )` 
+**`triangle(x0, y0, x1, y1, x2, y2, c [, f:bool] )`**
 
 Draw a triangle with vertices at points `x0,y0` , `x1,y1` and `x2,y2` and border colour, `c` (integer). Optionally fill the circle by adding `f=True`.
 
@@ -52,10 +52,15 @@ Works with MicroPython version 1.19.1. Will also work with other versions.
 
 ## Release notes
 
+#### v208
+
+- fix for issue #1
+- fix for an issue where filled triangles were not drawn properly around the middle vertex (middle in vertical order)  
+
 #### v206
 
 - large_text() enhanced by the addition of rotation parameter 
-- substantial speed improvements to the large_text() method
+- substantial speed improvements
 
 #### v202
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Works with MicroPython version 1.19.1. Will also work with other versions.
 #### v206
 
 - large_text() enhanced by the addition of rotation parameter 
-- substantial speed improvements
+- substantial speed improvements  to the large_text() method
 
 #### v202
 

--- a/framebuf2.py
+++ b/framebuf2.py
@@ -1,7 +1,7 @@
 # this code is distributed under the MIT licence.
 
 """
-frambuf2 v206: micropython framebuffer extensions
+frambuf2 v208: micropython framebuffer extensions
 (c) 2022-2023 Peter Lumb (peter-l5)
 
 acknowledgement
@@ -15,7 +15,7 @@ Author: Tony DiCola (original GFX author Phil Burgess)
 License: MIT License (https://opensource.org/licenses/MIT)
 """
 
-__version__ = "v206"
+__version__ = "v208"
 __repo__ = "https://github.com/peter-l5/framebuf2"
 
 import framebuf
@@ -152,7 +152,6 @@ class FrameBuffer(framebuf.FrameBuffer):
                 x0, x1 = x1, x0
             a = 0
             b = 0
-            y = 0
             last = 0
             if y0 == y2:
                 a = x0
@@ -181,11 +180,12 @@ class FrameBuffer(framebuf.FrameBuffer):
                 dy12 = 1
             sa = 0
             sb = 0
-            if y1 == y2:
-                last = y1
+            y = y0
+            if y0 == y1:
+                last = y1 - 1
             else:
-                last = y1-1
-            for y in range(y0, last+1):
+                last = y1
+            while y <= last: 
                 a = x0 + sa // dy01
                 b = x0 + sb // dy02
                 sa += dx01
@@ -193,6 +193,7 @@ class FrameBuffer(framebuf.FrameBuffer):
                 if a > b:
                     a, b = b, a
                 self.hline(a, y, b-a+1, c)
+                y += 1
             sa = dx12 * (y - y1)
             sb = dx02 * (y - y0)
             while y <= y2:


### PR DESCRIPTION
fix for issue #1 where filled triangles with a flat lower edge were not drawn correctly.
also a fix for a bug where filled triangles were drawn slightly incorrectly around the middle (in vertically order) vertex 